### PR TITLE
Fixed the compilation error caused by having no assets in the Pod

### DIFF
--- a/JDFPeekaboo.podspec
+++ b/JDFPeekaboo.podspec
@@ -24,9 +24,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.source_files = 'Pod/Classes'
-  s.resource_bundles = {
-    'JDFPeekaboo' => ['Pod/Assets/*.png']
-  }
 
   s.frameworks = 'UIKit'
 end


### PR DESCRIPTION
I removed the `resource_bundles` part of the Podspec because it was causing Xcode to reference an inexistent `JDFPeekaboo.bundle`.
