### PR TITLE
Fix scroll indicator insets handling

### DIFF
--- a/Pod/Classes/JDFPeekabooCoordinator.m
+++ b/Pod/Classes/JDFPeekabooCoordinator.m
@@ -234,6 +234,10 @@ static CGFloat const JDFPeekabooCoordinatorNavigationBarHorizontalHeightDifferen
     [self.topView setFrame:topBarFrame];
     [self.bottomView setFrame:bottomBarFrame];
     
+    CGFloat top = topBarFrame.origin.y + topBarFrame.size.height;
+    CGFloat bottom = self.scrollView.frame.size.height - bottomBarFrame.origin.y;
+    self.scrollView.scrollIndicatorInsets = UIEdgeInsetsMake(top, 0, bottom, 0);
+    
     CGFloat topViewPercentageHidden = [self topViewPercentageHidden];
     [self updateTopViewSubviews:(1 - topViewPercentageHidden)];
         


### PR DESCRIPTION
When you scroll, scroll indicators has wrong insets. For example, in demo project, there is table view, and if bottom bar is hidden, table view scroll indicator does not reach the bottom edge.
